### PR TITLE
Anpassung Struktur von Pub-/Management-Software

### DIFF
--- a/skos-software.md
+++ b/skos-software.md
@@ -2,21 +2,19 @@
 
 Empfehlenswerte Tools für die Arbeit mit SKOS-Vokabularen.
 
-Management:
+Management und Veröffentlichung:
 
 * [iQvoc](https://iqvoc.net/)
 * [TemaTres](https://vocabularyserver.com)
 * [VocBench](http://vocbench.uniroma2.it/)
+* [SkoHub Vocabs](https://github.com/hbz/skohub-vocabs)
+* [Skosmos](http://skosmos.org) (nur Veröffentlichung)
+
 
 Validierung:
 
 * [SKOS testing tool](http://labs.sparna.fr/skos-testing-tool/)
 * [Skosify](https://github.com/NatLibFi/Skosify)
-
-Veröffentlichung:
-
-* [Skosmos](http://skosmos.org)
-* [SkoHub Vocabs](https://github.com/hbz/skohub-vocabs)
 
 Visualisierung:
 


### PR DESCRIPTION
Da SkoHub auf GitHub/GitLab aufsetzt, hat es auch eine Lösung für das Vokabular.Management integriert, welche die dort bekannten Funktionen (z.B. pull/merge request) nutzt. Von daher ist es nicht eine reine Publikationssoftware. Das gilt m.W. nur für Skosmos.